### PR TITLE
feat: use mirror in more download step

### DIFF
--- a/helpers/environment.bat
+++ b/helpers/environment.bat
@@ -4,7 +4,7 @@
 set "git_github_url=https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/PortableGit-2.47.1.2-64-bit.7z.exe"
 set "git_sourceforge_url=https://cyfuture.dl.sourceforge.net/project/git-for-windows.mirror/v2.47.1.windows.2/PortableGit-2.47.1.2-64-bit.7z.exe?viasf=1"
 :: Mirror provided by NJU, see https://mirror.nju.edu.cn/ for more information
-:: Why no Tsinghua or BFSU mirror: it block my IP CIDR for "download large binary file too frequently"
+:: Why no Tsinghua or BFSU mirror: can block the download if used too much.
 set "git_tsinghua_url=https://mirror.nju.edu.cn/github-release/git-for-windows/git/Git for Windows v2.48.1.windows.1/PortableGit-2.48.1-64-bit.7z.exe"
 
 set git_save_path="%cd%\PortableGit.7z.exe"
@@ -14,8 +14,8 @@ set git_extract_path="%cd%\system\git"
 :: Python
 set "python_url=https://www.python.org/ftp/python/3.12.8/python-3.12.8-embed-amd64.zip"
 :: Mirror provided by NJU, see https://mirror.nju.edu.cn/ for more information
-:: Why no Tsinghua mirror: it didn't provide python releases mirror
-:: Why no USTC: it will trigger browser verification
+:: Why no Tsinghua mirror: it didn't provide python releases mirror.
+:: Why no USTC: it will trigger browser verification.
 set "python_tsinghua_url=https://mirror.nju.edu.cn/python/3.12.8/python-3.12.8-embed-amd64.zip"
 set "python_save_path=%cd%\Python-3.12.8.zip"
 

--- a/helpers/environment.bat
+++ b/helpers/environment.bat
@@ -3,13 +3,20 @@
 :: Git
 set "git_github_url=https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/PortableGit-2.47.1.2-64-bit.7z.exe"
 set "git_sourceforge_url=https://cyfuture.dl.sourceforge.net/project/git-for-windows.mirror/v2.47.1.windows.2/PortableGit-2.47.1.2-64-bit.7z.exe?viasf=1"
+:: Mirror provided by NJU, see https://mirror.nju.edu.cn/ for more information
+:: Why no Tsinghua or BFSU mirror: it block my IP CIDR for "download large binary file too frequently"
+set "git_tsinghua_url=https://mirror.nju.edu.cn/github-release/git-for-windows/git/Git for Windows v2.48.1.windows.1/PortableGit-2.48.1-64-bit.7z.exe"
 
-set git_save_path="%cd%\PortableGit-2.47.1.2-64-bit.7z.exe"
+set git_save_path="%cd%\PortableGit.7z.exe"
 set git_zip_path="%git_save_path%"
 set git_extract_path="%cd%\system\git"
 
 :: Python
 set "python_url=https://www.python.org/ftp/python/3.12.8/python-3.12.8-embed-amd64.zip"
+:: Mirror provided by NJU, see https://mirror.nju.edu.cn/ for more information
+:: Why no Tsinghua mirror: it didn't provide python releases mirror
+:: Why no USTC: it will trigger browser verification
+set "python_tsinghua_url=https://mirror.nju.edu.cn/python/3.12.8/python-3.12.8-embed-amd64.zip"
 set "python_save_path=%cd%\Python-3.12.8.zip"
 
 set "python_zip_path=%python_save_path%"
@@ -23,8 +30,15 @@ set "tkinter_path=%cd%\additional_modules\tkinter-standalone-main\3.12\python_em
 set "dpg_markdown=%cd%\additional_modules\DearPyGui-Markdown-main"
 
 :: Pip
+:: I didn't find any mirror provide get-pip.py
 set "pip_url=https://bootstrap.pypa.io/get-pip.py"
 set "pip_save_path=%python_extract_path%\get-pip.py"
 
 :: PATH
 set PATH=%cd%\system\git\bin;%cd%\system\python;%cd%\system\python\Scripts;%cd%\app;%PATH%
+
+:: Mirror (handle %USE_TSINGHUA%)
+:: Git url handle by git.bat
+if "%USE_TSINGHUA%"=="1" (
+    set "python_url=%python_tsinghua_url%"
+)

--- a/helpers/git.bat
+++ b/helpers/git.bat
@@ -26,7 +26,15 @@ if not exist %git_extract_path% (
     )
 )
 
-echo Downloading Git from GitHub. Expect a file size of around 63000000 bytes (63 MB)...
+if "%USE_TSINGHUA%"=="" (
+    echo Downloading Git from Github. Expect a file size of around 63000000 bytes ^(63 MB^)
+) else if "%USE_TSINGHUA%"=="1" (
+    echo Downloading Git from NJU mirror. Expect a file size of around 63000000 bytes ^(63 MB^)
+    set "git_github_url=%git_tsinghua_url%"
+) else (
+    echo Invalid mirror option: %USE_TSINGHUA%
+)
+
 echo %git_github_url%
 powershell -Command "Invoke-WebRequest -Uri '%git_github_url%' -OutFile '%git_save_path%'"
 if %errorlevel% neq 0 (

--- a/helpers/python.bat
+++ b/helpers/python.bat
@@ -63,13 +63,13 @@ echo ^> Done.
 echo Downloading build requirements...
 :: Install wheel, setuptools and poetry in addition to the launcher requirements
 if "%USE_TSINGHUA%"=="1" (
-    "%python_extract_path%\python.exe" -m pip install --no-warn-script-location wheel setuptools poetry -i https://pypi.tuna.tsinghua.edu.cn/simple
+    "%python_extract_path%\python.exe" -m pip install --no-warn-script-location wheel setuptools poetry -i https://mirrors.aliyun.com/pypi/simple
 
     echo Downloading launcher requirements...
-    "%python_extract_path%\python.exe" -m pip install --no-warn-script-location psutil dearpygui GitPython pygetwindow -i https://pypi.tuna.tsinghua.edu.cn/simple
+    "%python_extract_path%\python.exe" -m pip install --no-warn-script-location psutil dearpygui GitPython pygetwindow -i https://mirrors.aliyun.com/pypi/simple
 
     echo Installing DearPyGui-Markdown...
-    "%python_extract_path%\python.exe" -m pip install -e "%dpg_markdown%" -i https://pypi.tuna.tsinghua.edu.cn/simple
+    "%python_extract_path%\python.exe" -m pip install -e "%dpg_markdown%" -i https://mirrors.aliyun.com/pypi/simple
     
 ) else (
     "%python_extract_path%\python.exe" -m pip install --no-warn-script-location wheel setuptools poetry

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -164,7 +164,8 @@ def pip_install_with_progress(requirements_file_path):
                                     text += "\nCalculating remaining time -"
                                     
                             text += f" {int(downloaded_size / 1_000_000)}mb/{int(total_size / 1_000_000)}mb"
-                            text += f" @ {(sum(download_speeds) / len(download_speeds)) / 1_000_000:.2f}mb/s"
+                            if len(download_speeds) > 0:
+                                text += f" @ {(sum(download_speeds) / len(download_speeds)) / 1_000_000:.2f}mb/s"
                             
                         dpg.configure_item("requirements_progress_text", default_value=text)
                     except ValueError:
@@ -481,7 +482,7 @@ with dpg.window(tag="InstallOptions", no_title_bar=True, no_collapse=True, no_cl
             with dpg.group():
                 dpg.add_text("Additional options:")
                 dpg.add_checkbox(label="Install with NVIDIA compatibility", tag="nvidia")
-                dpg.add_checkbox(label="Use Alibaba Cloud (also named as Aliyun) PyPI mirror and NJU PyTorch Mirror", tag="tsinghua")
+                dpg.add_checkbox(label="Use Aliyun and NJU mirrors.", tag="tsinghua")
                 
                 with dpg.tooltip("nvidia", hide_on_activity=True, delay=0.1):
                     dpg.add_text("If you have an NVIDIA GPU, you can choose download the NVIDIA compatible version of packages for better performance.\n\nNOTE: Requires at least 3gb of extra storage!", wrap=200)
@@ -490,7 +491,7 @@ with dpg.window(tag="InstallOptions", no_title_bar=True, no_collapse=True, no_cl
 
 def update_recap_page():
     dpg.configure_item("install_location", default_value=f"{os.path.abspath(install_folder)}")
-    download_server_text = dpg.get_value("download_server") + " with Tsinghua PyPI mirror" if dpg.get_value("tsinghua") else dpg.get_value("download_server")
+    download_server_text = dpg.get_value("download_server") + " with Aliyun and NJU mirrors" if dpg.get_value("tsinghua") else dpg.get_value("download_server")
     dpg.configure_item("download_server_text", default_value=f"{download_server_text}")
     
 with dpg.window(tag="Recap", no_title_bar=True, no_collapse=True, no_close=True, no_resize=True, no_move=True, no_background=True, no_scrollbar=True, show=False, width=500, height=270) as window:

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -98,9 +98,13 @@ def pip_install_with_progress(requirements_file_path):
     index_urls = []
     
     if dpg.get_value("nvidia"):
-        index_urls += ["https://download.pytorch.org/whl/cu126"]
+        if dpg.get_value("tsinghua"):
+            # Mirror provided by NJU, see https://mirror.nju.edu.cn/ for more information.
+            index_urls += ["https://mirror.nju.edu.cn/pytorch/whl/cu126"]
+        else:
+            index_urls += ["https://download.pytorch.org/whl/cu126"]
     if dpg.get_value("tsinghua"):
-        index_urls += ["https://pypi.tuna.tsinghua.edu.cn/simple"]
+        index_urls += ["https://mirrors.aliyun.com/pypi/simple/"]
     else:
         index_urls += ["https://pypi.org/simple"] # Default index.
         
@@ -477,12 +481,12 @@ with dpg.window(tag="InstallOptions", no_title_bar=True, no_collapse=True, no_cl
             with dpg.group():
                 dpg.add_text("Additional options:")
                 dpg.add_checkbox(label="Install with NVIDIA compatibility", tag="nvidia")
-                dpg.add_checkbox(label="Use Tsinghua PyPI mirror", tag="tsinghua")
+                dpg.add_checkbox(label="Use Alibaba Cloud (also named as Aliyun) PyPI mirror and NJU PyTorch Mirror", tag="tsinghua")
                 
                 with dpg.tooltip("nvidia", hide_on_activity=True, delay=0.1):
                     dpg.add_text("If you have an NVIDIA GPU, you can choose download the NVIDIA compatible version of packages for better performance.\n\nNOTE: Requires at least 3gb of extra storage!", wrap=200)
                 with dpg.tooltip("tsinghua", hide_on_activity=True, delay=0.1):
-                    dpg.add_text("Tsinghua is a Chinese university that hosts it's own PyPI mirror. If you have issues connecting to the official PyPI servers please enable this.", wrap=200)
+                    dpg.add_text("Alibaba Cloud (also named as Aliyun) is a Chinese cloud service provider with its own PyPI mirror, while NJU is a Chinese university with its own PyTorch mirror. If you are having problems connecting to the official PyPI or PyTorch servers, enable this.", wrap=200)
 
 def update_recap_page():
     dpg.configure_item("install_location", default_value=f"{os.path.abspath(install_folder)}")


### PR DESCRIPTION
## Summary

- replace tsinghua PyPI mirror with Alibaba Cloud's PyPI mirror (because tsinghua has a very strict anti-abuse system)
- use NJU's PyTorch Mirror when install with NVIDIA compatibility and use mirror option is checked
- use NJU mirror to download Git and Python when start with `start_tsinghua.bat`

## Notes:

- download large binary file from USTC mirror will trigger broswer verification
- BFSU have same anti-abuse system as TUNA (tsinghua)

maybe we can provide a option let user use custom mirror?